### PR TITLE
Fix profanity nodes and bad class serializing

### DIFF
--- a/client/src/app/game/chat/chat.tsx
+++ b/client/src/app/game/chat/chat.tsx
@@ -15,19 +15,16 @@ import {setSetting} from 'logic/local-settings/local-settings-actions'
 import {useDrag} from '@use-gesture/react'
 import {FormattedText} from 'components/formatting/formatting'
 import classNames from 'classnames'
-import {LineNode} from 'common/utils/formatting'
 
 function Chat() {
 	const dispatch = useDispatch()
 	const settings = useSelector(getSettings)
 	const chatMessages = settings.disableChat === 'off' ? useSelector(getChatMessages) : []
-	const playerStates = useSelector(getPlayerStates)
 	const playerId = useSelector(getPlayerId)
 	const opponent = useSelector(getOpponentName)
 	const chatPosSetting = settings.chatPosition
 	const chatSize = settings.chatSize
 	const showLog = settings.showBattleLogs
-	const opponentId = useSelector(getOpponentId)
 
 	const [chatPos, setChatPos] = useState({x: 0, y: 0})
 
@@ -106,13 +103,12 @@ function Chat() {
 							minute: '2-digit',
 						})
 
-						const opponent = playerId !== line.sender
-						const opponentName = opponentId ? playerStates?.[opponentId].playerName : null
+						const isOpponent = playerId !== line.sender
 						if (line.message.TYPE === 'LineNode') {
 							return (
 								<div className={css.message}>
 									<span className={css.turnTag}>
-										{opponent ? `${opponentName}'s`.toLocaleUpperCase() : 'YOUR'} TURN
+										{isOpponent ? `${opponent}'s`.toLocaleUpperCase() : 'YOUR'} TURN
 									</span>
 									<span className={css.line}></span>
 								</div>
@@ -124,7 +120,7 @@ function Chat() {
 								<span className={css.time}>{hmTime}</span>
 								<span className={classNames(line.systemMessage ? css.systemMessage : css.text)}>
 									{FormattedText(line.message, {
-										isOpponent: opponent,
+										isOpponent,
 										censorProfanity: settings.profanityFilter === 'on',
 									})}
 								</span>

--- a/client/src/app/game/chat/chat.tsx
+++ b/client/src/app/game/chat/chat.tsx
@@ -1,11 +1,6 @@
 import {SyntheticEvent, useState} from 'react'
 import {useDispatch, useSelector} from 'react-redux'
-import {
-	getChatMessages,
-	getOpponentId,
-	getOpponentName,
-	getPlayerStates,
-} from 'logic/game/game-selectors'
+import {getChatMessages, getOpponentName} from 'logic/game/game-selectors'
 import {chatMessage} from 'logic/game/game-actions'
 import {getPlayerId} from 'logic/session/session-selectors'
 import {getSettings} from 'logic/local-settings/local-settings-selectors'
@@ -21,7 +16,7 @@ function Chat() {
 	const settings = useSelector(getSettings)
 	const chatMessages = settings.disableChat === 'off' ? useSelector(getChatMessages) : []
 	const playerId = useSelector(getPlayerId)
-	const opponent = useSelector(getOpponentName)
+	const opponentName = useSelector(getOpponentName)
 	const chatPosSetting = settings.chatPosition
 	const chatSize = settings.chatSize
 	const showLog = settings.showBattleLogs
@@ -85,7 +80,7 @@ function Chat() {
 			}}
 		>
 			<div className={css.header} {...bindChatPos()}>
-				<p>Chatting with {opponent}</p>
+				<p>Chatting with {opponentName}</p>
 				<Button onClick={() => dispatch(setSetting('showBattleLogs', !showLog))} size="small">
 					{showLog ? 'Hide Battle Log' : 'Show Battle Log'}
 				</Button>
@@ -108,7 +103,7 @@ function Chat() {
 							return (
 								<div className={css.message}>
 									<span className={css.turnTag}>
-										{isOpponent ? `${opponent}'s`.toLocaleUpperCase() : 'YOUR'} TURN
+										{isOpponent ? `${opponentName}'s`.toLocaleUpperCase() : 'YOUR'} TURN
 									</span>
 									<span className={css.line}></span>
 								</div>

--- a/client/src/components/formatting/formatting.tsx
+++ b/client/src/components/formatting/formatting.tsx
@@ -1,12 +1,4 @@
-import {
-	DifferentTextNode,
-	FormatNode,
-	ListNode,
-	FormattedTextNode,
-	TextNode,
-	ProfanityNode,
-	EmojiNode,
-} from 'common/utils/formatting'
+import {FormattedTextNode, censor} from 'common/utils/formatting'
 
 import css from './formatting.module.scss'
 import classNames from 'classnames'
@@ -20,49 +12,38 @@ function nodeToHtml(node: FormattedTextNode, settings: DisplaySettings) {
 	if (node.TYPE == 'ListNode') {
 		let html = []
 
-		for (let child of (node as ListNode).nodes) {
+		for (let child of node.nodes) {
 			html.push(nodeToHtml(child, settings))
 		}
 		return <span>{html}</span>
 	} else if (node.TYPE == 'EmptyNode') {
 		return <div />
 	} else if (node.TYPE == 'TextNode') {
-		return <span>{(node as TextNode).text}</span>
+		return <span>{node.text}</span>
 	} else if (node.TYPE == 'FormatNode') {
-		const formatNode = node as FormatNode
-
 		return (
 			<span
-				className={classNames(
-					css[formatNode.format],
-					settings.isOpponent ? css.viewedByOpponent : ''
-				)}
+				className={classNames(css[node.format], settings.isOpponent ? css.viewedByOpponent : '')}
 			>
-				{nodeToHtml(formatNode.text, settings)}
+				{nodeToHtml(node.text, settings)}
 			</span>
 		)
 	} else if (node.TYPE == 'DifferentTextNode') {
-		let differentTextNode = node as DifferentTextNode
-
 		return (
 			<span>
 				{settings.isOpponent
-					? nodeToHtml(differentTextNode.opponentText, settings)
-					: nodeToHtml(differentTextNode.playerText, settings)}
+					? nodeToHtml(node.opponentText, settings)
+					: nodeToHtml(node.playerText, settings)}
 			</span>
 		)
 	} else if (node.TYPE == 'ProfanityNode') {
-		let profanityNode = node as ProfanityNode
-
 		if (settings.censorProfanity) {
-			return <span> {profanityNode.censor()} </span>
+			return <span> {censor(node)} </span>
 		}
-		return <span>{profanityNode.text}</span>
+		return <span>{node.text}</span>
 	} else if (node.TYPE == 'EmojiNode') {
-		const emojiNode = node as EmojiNode
-
-		const link = `/images/hermits-emoji/${emojiNode.emoji.toLowerCase()}.png`
-		const alt = `:${emojiNode.emoji}:`
+		const link = `/images/hermits-emoji/${node.emoji.toLowerCase()}.png`
+		const alt = `:${node.emoji}:`
 
 		return <img className={css.emoji} src={link} alt={alt} />
 	} else if (node.TYPE == 'LineBreakNode') {

--- a/common/models/battle-log-model.ts
+++ b/common/models/battle-log-model.ts
@@ -74,7 +74,7 @@ export class BattleLogModel {
 
 			this.game.chat.push({
 				createdAt: Date.now(),
-				message: formatText(firstEntry.description),
+				message: formatText(firstEntry.description, {censor: true}),
 				sender: firstEntry.player,
 				systemMessage: true,
 			})
@@ -311,7 +311,7 @@ export class BattleLogModel {
 	public addTurnEndEntry() {
 		this.game.chat.push({
 			createdAt: Date.now(),
-			message: new LineNode(),
+			message: {TYPE: 'LineNode'},
 			sender: this.game.opponentPlayer.id,
 			systemMessage: true,
 		})

--- a/server/src/routines/background/chat.ts
+++ b/server/src/routines/background/chat.ts
@@ -18,7 +18,7 @@ function* chatMessageSaga(game: GameModel, action: AnyAction) {
 
 	game.chat.push({
 		message: concatFormattedTextNodes(
-			formatText(`$p${game.players[playerId].name}$ `),
+			formatText(`$p${game.players[playerId].name}$ `, {censor: true}),
 			formatText(message, {
 				censor: true,
 				'enable-$': false,


### PR DESCRIPTION
- Fixes ProfanityNodes crashing client with filter enabled
- Fixes chat not censoring player names
- Fixes FormattedTextNodes being defined as classes instead of types